### PR TITLE
Add swap_usage_evaluation_periods parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,7 @@ locals {
     PercentFreeMemoryThreshold         = max(var.percent_free_memory_threshold, 0)
     FreeStorageSpaceThreshold          = max(var.free_storage_space_threshold, 0)
     SwapUsageThreshold                 = max(var.swap_usage_threshold, 0)
+    SwapUsageEvaluationPeriods         = max(var.swap_usage_evaluation_periods, 0)
   }
 }
 
@@ -282,7 +283,7 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_high" {
   for_each                  = var.db_cluster_members
   alarm_name                = "${each.key}_swap_usage_high"
   comparison_operator       = "GreaterThanThreshold"
-  evaluation_periods        = "1"
+  evaluation_periods        = local.thresholds["SwapUsageEvaluationPeriods"]
   metric_name               = "SwapUsage"
   namespace                 = "AWS/RDS"
   period                    = "60"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "swap_usage_threshold" {
   # 256 Megabyte in Byte
 }
 
+variable "swap_usage_evaluation_periods" {
+  description = "The number of periods threshold must be breached to alarm."
+  type        = number
+  default     = 5
+}
+
 variable "percent_free_memory_threshold" {
   description = "The percent of memory that is unused."
   type        = number


### PR DESCRIPTION
This allows the swap usage alarm more flexibility (instead of being hard coded to 1).
